### PR TITLE
report: render detail link with trailing slash

### DIFF
--- a/ducktape/templates/report/report.html
+++ b/ducktape/templates/report/report.html
@@ -76,7 +76,7 @@
           var className = this.props.test.test_result;
           var detailCol;
           if (className !== "ignore") {
-            detailCol = <td colSpan='5' align='center'><pre><a href={this.props.test.test_log}>Detail</a></pre></td>
+            detailCol = <td colSpan='5' align='center'><pre><a href={this.props.test.test_log + '/'}>Detail</a></pre></td>
           } else {
             detailCol = <td colSpan='5' align='center'></td>
           }


### PR DESCRIPTION
This is useful when serving from something like s3.

Signed-off-by: Noah Watkins <noahwatkins@gmail.com>